### PR TITLE
Validation of the short & long form options on the command line.

### DIFF
--- a/lib/optioneer.rb
+++ b/lib/optioneer.rb
@@ -164,14 +164,6 @@ module Optioneer
       false
     end
 
-    # Given a long option, will return the name of the matching Option.
-    def find_name_by_long(long)
-      @expected_options.each do |opt|
-        return opt.name if opt.values[:long] == long
-      end
-      nil
-    end
-
     # given a long option will get the matching short
     def get_short_from_long(long)
       @expected_options.each do |opt|

--- a/lib/optioneer.rb
+++ b/lib/optioneer.rb
@@ -47,7 +47,7 @@ module Optioneer
           @options[:action] = opt
         end
       end
-      @passed_options.count
+      @passed_options.count unless check_duplicate
     end
 
     # return the 'action' assiciated with the command line
@@ -139,16 +139,21 @@ module Optioneer
         which == :long ? new_option.long = the_opt : new_option.short = the_opt
         # if an arg exists, add this to the option data
         new_option.argument = the_arg if the_arg
-        # check for both short and long options and fail if so
-        # check_duplicate(expected)
         # add the newly decoded option to the list
         @passed_options[expected.name] = new_option
       end
     end
 
-    def check_duplicate(expected)
+    def check_duplicate
       # determine if we have both short and long form of the same option,
       # and raise error if so.
+      cmdline.each do |opt|
+        next unless opt =~ /^--/
+        short = "-#{get_short_from_long(opt.delete!('-'))}"
+        next unless @options[:cmdline].include?(short)
+        raise 'You cannot combine both long and short versions of an option!'
+      end
+      false
     end
 
     # Given a name, will return the object if the matching Option exists.
@@ -157,6 +162,22 @@ module Optioneer
         return opt if opt.name == name
       end
       false
+    end
+
+    # Given a long option, will return the name of the matching Option.
+    def find_name_by_long(long)
+      @expected_options.each do |opt|
+        return opt.name if opt.values[:long] == long
+      end
+      nil
+    end
+
+    # given a long option will get the matching short
+    def get_short_from_long(long)
+      @expected_options.each do |opt|
+        return opt.values[:short] if opt.values[:long] == long
+      end
+      nil
     end
   end
 end

--- a/spec/parse_spec.rb
+++ b/spec/parse_spec.rb
@@ -45,7 +45,7 @@ describe Optioneer do
       opts.add(:four, short: 'd', arg: 'DIRECTORY')
       expect { opts.parse }.to raise_error(RuntimeError, 'You cannot combine both long and short versions of an option!')
     end
-    skip 'will only allow registered options' do
+    it 'will only allow registered options', skip: 'Functionality and test still to be written' do
     end
     it 'returns the action specified' do
       subject.parse

--- a/spec/parse_spec.rb
+++ b/spec/parse_spec.rb
@@ -31,7 +31,7 @@ describe Optioneer do
       expect(subject[:three].values[:arg]).to eq 'option'
       expect(subject[:four].values[:arg]).to eq 'directory'
     end
-    skip 'will not allow both the short and long form' do
+    it 'will not allow both the short and long form' do
       ARGV.clear
       # this should return 4 switches (2 with options) and one action
       @cmd = %w(-r --recurse --quiet --switch=option -d directory action)

--- a/spec/parse_spec.rb
+++ b/spec/parse_spec.rb
@@ -1,6 +1,5 @@
 # rubocop:disable LineLength
 require 'spec_helper'
-require 'yaml'
 
 describe Optioneer do
   subject { Optioneer::Optioneer.new }


### PR DESCRIPTION
If both the short and long form of a specific option are specified on the command line, the library will raise an exception and terminate.